### PR TITLE
Fix up swagger UI for /assignment and /assignment/{id}

### DIFF
--- a/management-server/src/main/kotlin/ut/isep/management/controller/AssignmentController.kt
+++ b/management-server/src/main/kotlin/ut/isep/management/controller/AssignmentController.kt
@@ -1,7 +1,6 @@
 package ut.isep.management.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -45,13 +44,6 @@ class AssignmentController {
     @ApiResponse(
         responseCode = "200",
         description = "Returns a list of all assignments",
-        content = [Content(
-            mediaType = "application/json",
-            array = ArraySchema(
-                schema = Schema(
-                    implementation = Assignment::class
-                ))
-        )]
     )
     fun getAssignments(): List<Assignment> {
        return listOf(AssignmentMultipleChoice(
@@ -68,12 +60,6 @@ class AssignmentController {
         ApiResponse(
             responseCode = "200",
             description = "Found the assignment",
-            content = [Content(
-                mediaType = "application/json",
-                schema = Schema(
-                    implementation = Assignment::class
-                ))
-            ]
         ),
         ApiResponse(
             responseCode = "404",

--- a/shared-models/src/main/kotlin/models/Assignment.kt
+++ b/shared-models/src/main/kotlin/models/Assignment.kt
@@ -9,6 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema
     ]
 )
 @Schema(
-    oneOf = [AssignmentCoding::class, AssignmentMultipleChoice::class]
+    description = "Either a coding or a multiple choice assignment"
 )
 sealed class Assignment


### PR DESCRIPTION
The swagger documentation now shows the proper schemas for GET /assignment and GET /assignment/{id}, but not their media type. The @Content property in @ApiRespones annotation seems to break this, so I have completely avoided it for now.